### PR TITLE
fix: headers cannot be set

### DIFF
--- a/src/lib/api-fetch.ts
+++ b/src/lib/api-fetch.ts
@@ -6,9 +6,7 @@ export const apiFetch = ofetch.create({
   onRequest: async ({ options }) => {
     const header = new Headers(options.headers)
 
-    options.headers = {
-      ...header,
-    }
+    options.headers = header
 
     if (options.method && options.method.toLowerCase() !== "get") {
       if (typeof options.body === "string") {


### PR DESCRIPTION
Problem: When using options.headers = { ...header }, the headers were not correctly applied to the request.

Solution: I replaced options.headers = { ...header } with options.headers = header. By assigning the headers directly, the issue is resolved, and the HTTP headers are now set correctly.